### PR TITLE
fix: AsyncImage, VH UI, Back filter

### DIFF
--- a/WPFEcommerceApp/WPFEcommerceApp/Api/GenerateID.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Api/GenerateID.cs
@@ -49,6 +49,14 @@ namespace WPFEcommerceApp {
                     res = context.Database.SqlQuery<int>(sql).Single();
                 }
             });
+
+            #region Fake ID
+            //string id = type.Name.Substring(0, 4);
+            //id = id + (res + 50).ToString();
+            //50 thay bằng các số bắt đầu của mỗi người
+            #endregion
+
+            #region Real ID
             bool check = false;
             string id = "";
             while(!check) {
@@ -70,6 +78,7 @@ namespace WPFEcommerceApp {
                 });
                 if(!check) res = (long)(res * 1.5);
             }
+            #endregion
 
             return id;
         }

--- a/WPFEcommerceApp/WPFEcommerceApp/App.config
+++ b/WPFEcommerceApp/WPFEcommerceApp/App.config
@@ -1,9 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+      <section name="WPFEcommerceApp.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
   <connectionStrings>
-    <add name="EcommerceAppEntities" connectionString="metadata=res://*/Models.Model.csdl|res://*/Models.Model.ssdl|res://*/Models.Model.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=DESKTOP-T3VCTA6;initial catalog=EcommerceApp;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />
+    <add name="EcommerceAppEntities" connectionString="metadata=res://*/Models.Model.csdl|res://*/Models.Model.ssdl|res://*/Models.Model.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=VU-HOANG\SQLEXPRESS;initial catalog=EcommerceApp;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />
   </connectionStrings>
+  <!--Unexpected errors will occur if the userSettings is not set.-->
+  <userSettings>
+    <WPFEcommerceApp.Properties.Settings>
+      <setting name="Cookie" serializeAs="String">
+        <value />
+      </setting>
+    </WPFEcommerceApp.Properties.Settings>
+  </userSettings>
 </configuration>

--- a/WPFEcommerceApp/WPFEcommerceApp/Components/UserControls/AsyncImage/AsyncImage.xaml
+++ b/WPFEcommerceApp/WPFEcommerceApp/Components/UserControls/AsyncImage/AsyncImage.xaml
@@ -11,10 +11,13 @@
     <Grid>
         <Image Source="{Binding ElementName=image, Path=Default}" 
                x:Name="imgDefault"
-               Stretch="{Binding ElementName=image, Path=Stretch}"/>
+               Width="{Binding ElementName=imgAsync, Path=ActualWidth}"
+               Height="{Binding ElementName=imgAsync, Path=ActualHeight}"/>
         <Image Source="{Binding ElementName=image, Path=Source}"
                x:Name="imgAsync"
                Stretch="{Binding ElementName=image, Path=Stretch}">
+            
         </Image>
+        
     </Grid>
 </UserControl>

--- a/WPFEcommerceApp/WPFEcommerceApp/Components/UserControls/AsyncImage/AsyncImage.xaml.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Components/UserControls/AsyncImage/AsyncImage.xaml.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -57,7 +59,7 @@ namespace WPFEcommerceApp {
         public static readonly DependencyProperty ImgSourceProperty =
             DependencyProperty.Register("Source", typeof(ImageSource), typeof(AsyncImage), new PropertyMetadata(default(ImageSource), OnImgSourceChanged));
 
-        private static void OnImgSourceChanged(DependencyObject o, DependencyPropertyChangedEventArgs e) {
+        private static void OnImgSourceChanged(DependencyObject o, DependencyPropertyChangedEventArgs evt) {
             var x = o.GetValue(ImgSourceProperty) as ImageSource;
             try {
                 //Handle

--- a/WPFEcommerceApp/WPFEcommerceApp/Models/Model.edmx
+++ b/WPFEcommerceApp/WPFEcommerceApp/Models/Model.edmx
@@ -138,6 +138,7 @@
           <Property Name="IdSender" Type="varchar" MaxLength="30" Nullable="false" />
           <Property Name="Date" Type="smalldatetime" Nullable="false" />
           <Property Name="Content" Type="nvarchar" MaxLength="1000" Nullable="false" />
+          <Property Name="HaveSeen" Type="bit" />
         </EntityType>
         <EntityType Name="OrderInfo">
           <Key>
@@ -183,7 +184,7 @@
           </Key>
           <Property Name="Id" Type="varchar" MaxLength="8" Nullable="false" />
           <Property Name="IdShop" Type="varchar" MaxLength="30" Nullable="false" />
-          <Property Name="Code" Type="varchar" MaxLength="15" Nullable="false" />
+          <Property Name="Code" Type="nvarchar" MaxLength="15" Nullable="false" />
           <Property Name="Name" Type="nvarchar" MaxLength="150" />
           <Property Name="Description" Type="nvarchar" MaxLength="200" />
           <Property Name="DateBegin" Type="smalldatetime" />
@@ -219,7 +220,7 @@
           <Property Name="Id" Type="varchar" MaxLength="8" Nullable="false" />
           <Property Name="DateRating" Type="smalldatetime" />
           <Property Name="Rating" Type="int" />
-          <Property Name="Comment" Type="varchar" MaxLength="500" />
+          <Property Name="Comment" Type="nvarchar" MaxLength="500" />
         </EntityType>
         <EntityType Name="RatingInfo">
           <Key>
@@ -245,12 +246,13 @@
             <PropertyRef Name="IdUser" />
           </Key>
           <Property Name="IdUser" Type="varchar" MaxLength="30" Nullable="false" />
+          <Property Name="CreatedDate" Type="datetime" />
           <Property Name="Password" Type="varchar" MaxLength="100" />
-          <Property Name="Username" Type="varchar" MaxLength="100" />
+          <Property Name="Username" Type="nvarchar" MaxLength="100" />
           <Property Name="Salt" Type="varchar" MaxLength="100" />
           <Property Name="Provider" Type="int" />
         </EntityType>
-        <Association Name="FK__AdInUse__Id__5535A963">
+        <Association Name="FK__AdInUse__Id__5812160E">
           <End Role="Advertisement" Type="Self.Advertisement" Multiplicity="1" />
           <End Role="AdInUse" Type="Self.AdInUse" Multiplicity="*" />
           <ReferentialConstraint>
@@ -262,7 +264,7 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK__Cart__IdProduct__440B1D61">
+        <Association Name="FK__Cart__IdProduct__46E78A0C">
           <End Role="Product" Type="Self.Product" Multiplicity="1" />
           <End Role="Cart" Type="Self.Cart" Multiplicity="*" />
           <ReferentialConstraint>
@@ -274,7 +276,7 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK__Cart__IdUser__4316F928">
+        <Association Name="FK__Cart__IdUser__45F365D3">
           <End Role="MUser" Type="Self.MUser" Multiplicity="1" />
           <End Role="Cart" Type="Self.Cart" Multiplicity="*" />
           <ReferentialConstraint>
@@ -286,7 +288,7 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK__ShopReque__IdUse__70DDC3D8">
+        <Association Name="FK__ShopReque__IdUse__73BA3083">
           <End Role="MUser" Type="Self.MUser" Multiplicity="0..1" />
           <End Role="ShopRequest" Type="Self.ShopRequest" Multiplicity="*" />
           <ReferentialConstraint>
@@ -621,19 +623,19 @@
           <EntitySet Name="RatingInfo" EntityType="Self.RatingInfo" Schema="dbo" store:Type="Tables" />
           <EntitySet Name="ShopRequest" EntityType="Self.ShopRequest" Schema="dbo" store:Type="Tables" />
           <EntitySet Name="UserLogin" EntityType="Self.UserLogin" Schema="dbo" store:Type="Tables" />
-          <AssociationSet Name="FK__AdInUse__Id__5535A963" Association="Self.FK__AdInUse__Id__5535A963">
+          <AssociationSet Name="FK__AdInUse__Id__5812160E" Association="Self.FK__AdInUse__Id__5812160E">
             <End Role="Advertisement" EntitySet="Advertisement" />
             <End Role="AdInUse" EntitySet="AdInUse" />
           </AssociationSet>
-          <AssociationSet Name="FK__Cart__IdProduct__440B1D61" Association="Self.FK__Cart__IdProduct__440B1D61">
+          <AssociationSet Name="FK__Cart__IdProduct__46E78A0C" Association="Self.FK__Cart__IdProduct__46E78A0C">
             <End Role="Product" EntitySet="Product" />
             <End Role="Cart" EntitySet="Cart" />
           </AssociationSet>
-          <AssociationSet Name="FK__Cart__IdUser__4316F928" Association="Self.FK__Cart__IdUser__4316F928">
+          <AssociationSet Name="FK__Cart__IdUser__45F365D3" Association="Self.FK__Cart__IdUser__45F365D3">
             <End Role="MUser" EntitySet="MUser" />
             <End Role="Cart" EntitySet="Cart" />
           </AssociationSet>
-          <AssociationSet Name="FK__ShopReque__IdUse__70DDC3D8" Association="Self.FK__ShopReque__IdUse__70DDC3D8">
+          <AssociationSet Name="FK__ShopReque__IdUse__73BA3083" Association="Self.FK__ShopReque__IdUse__73BA3083">
             <End Role="MUser" EntitySet="MUser" />
             <End Role="ShopRequest" EntitySet="ShopRequest" />
           </AssociationSet>
@@ -767,7 +769,7 @@
             <End Role="MUser" EntitySet="MUsers" />
             <End Role="Address" EntitySet="Addresses" />
           </AssociationSet>
-          <AssociationSet Name="FK__AdInUse__Id__5535A963" Association="EcommerceAppModel.FK__AdInUse__Id__5535A963">
+          <AssociationSet Name="FK__AdInUse__Id__5812160E" Association="EcommerceAppModel.FK__AdInUse__Id__5812160E">
             <End Role="Advertisement" EntitySet="Advertisements" />
             <End Role="AdInUse" EntitySet="AdInUses" />
           </AssociationSet>
@@ -779,11 +781,11 @@
             <End Role="MUser" EntitySet="MUsers" />
             <End Role="BrandRequest" EntitySet="BrandRequests" />
           </AssociationSet>
-          <AssociationSet Name="FK__Cart__IdProduct__440B1D61" Association="EcommerceAppModel.FK__Cart__IdProduct__440B1D61">
+          <AssociationSet Name="FK__Cart__IdProduct__46E78A0C" Association="EcommerceAppModel.FK__Cart__IdProduct__46E78A0C">
             <End Role="Product" EntitySet="Products" />
             <End Role="Cart" EntitySet="Carts" />
           </AssociationSet>
-          <AssociationSet Name="FK__Cart__IdUser__4316F928" Association="EcommerceAppModel.FK__Cart__IdUser__4316F928">
+          <AssociationSet Name="FK__Cart__IdUser__45F365D3" Association="EcommerceAppModel.FK__Cart__IdUser__45F365D3">
             <End Role="MUser" EntitySet="MUsers" />
             <End Role="Cart" EntitySet="Carts" />
           </AssociationSet>
@@ -815,7 +817,7 @@
             <End Role="MOrder" EntitySet="MOrders" />
             <End Role="OrderInfo" EntitySet="OrderInfoes" />
           </AssociationSet>
-          <AssociationSet Name="FK__ShopReque__IdUse__70DDC3D8" Association="EcommerceAppModel.FK__ShopReque__IdUse__70DDC3D8">
+          <AssociationSet Name="FK__ShopReque__IdUse__73BA3083" Association="EcommerceAppModel.FK__ShopReque__IdUse__73BA3083">
             <End Role="MUser" EntitySet="MUsers" />
             <End Role="ShopRequest" EntitySet="ShopRequests" />
           </AssociationSet>
@@ -882,8 +884,8 @@
           <Property Name="IdProduct" Type="String" Nullable="false" MaxLength="8" FixedLength="false" Unicode="false" />
           <Property Name="Amount" Type="Int32" />
           <Property Name="Size" Type="String" Nullable="false" MaxLength="7" FixedLength="false" Unicode="false" />
-          <NavigationProperty Name="Product" Relationship="EcommerceAppModel.FK__Cart__IdProduct__440B1D61" FromRole="Cart" ToRole="Product" />
-          <NavigationProperty Name="MUser" Relationship="EcommerceAppModel.FK__Cart__IdUser__4316F928" FromRole="Cart" ToRole="MUser" />
+          <NavigationProperty Name="Product" Relationship="EcommerceAppModel.FK__Cart__IdProduct__46E78A0C" FromRole="Cart" ToRole="Product" />
+          <NavigationProperty Name="MUser" Relationship="EcommerceAppModel.FK__Cart__IdUser__45F365D3" FromRole="Cart" ToRole="MUser" />
           </EntityType>
         <EntityType Name="UserLogin">
           <Key>
@@ -891,9 +893,10 @@
           </Key>
           <Property Name="IdUser" Type="String" Nullable="false" MaxLength="30" FixedLength="false" Unicode="false" />
           <Property Name="Password" Type="String" MaxLength="100" FixedLength="false" Unicode="false" />
-          <Property Name="Username" Type="String" MaxLength="100" FixedLength="false" Unicode="false" />
+          <Property Name="Username" Type="String" MaxLength="100" FixedLength="false" Unicode="true" />
           <Property Name="Provider" Type="Int32" />
           <Property Name="Salt" Type="String" MaxLength="100" FixedLength="false" Unicode="false" />
+          <Property Name="CreatedDate" Type="DateTime" Precision="3" />
           <NavigationProperty Name="MUser" Relationship="EcommerceAppModel.FK_MUser_Id" FromRole="UserLogin" ToRole="MUser" />
         </EntityType>
         <EntityType Name="Address">
@@ -916,7 +919,7 @@
           </Key>
           <Property Name="Id" Type="String" Nullable="false" MaxLength="8" FixedLength="false" Unicode="false" />
           <Property Name="Position" Type="Int32" Nullable="false" />
-          <NavigationProperty Name="Advertisement" Relationship="EcommerceAppModel.FK__AdInUse__Id__5535A963" FromRole="AdInUse" ToRole="Advertisement" />
+          <NavigationProperty Name="Advertisement" Relationship="EcommerceAppModel.FK__AdInUse__Id__5812160E" FromRole="AdInUse" ToRole="Advertisement" />
         </EntityType>
         <EntityType Name="Advertisement">
           <Key>
@@ -924,7 +927,7 @@
           </Key>
           <Property Name="Id" Type="String" Nullable="false" MaxLength="8" FixedLength="false" Unicode="false" />
           <Property Name="Image" Type="String" Nullable="false" MaxLength="200" FixedLength="false" Unicode="true" />
-          <NavigationProperty Name="AdInUses" Relationship="EcommerceAppModel.FK__AdInUse__Id__5535A963" FromRole="Advertisement" ToRole="AdInUse" />
+          <NavigationProperty Name="AdInUses" Relationship="EcommerceAppModel.FK__AdInUse__Id__5812160E" FromRole="Advertisement" ToRole="AdInUse" />
         </EntityType>
         <EntityType Name="Brand">
           <Key>
@@ -1014,11 +1017,11 @@
           <Property Name="DefaultAddress" Type="String" MaxLength="14" FixedLength="false" Unicode="false" />
           <NavigationProperty Name="Addresses" Relationship="EcommerceAppModel.FK_Address_IdUser" FromRole="MUser" ToRole="Address" />
           <NavigationProperty Name="BrandRequests" Relationship="EcommerceAppModel.FK_BrandRequest_Shop" FromRole="MUser" ToRole="BrandRequest" />
-          <NavigationProperty Name="Carts" Relationship="EcommerceAppModel.FK__Cart__IdUser__4316F928" FromRole="MUser" ToRole="Cart" />
+          <NavigationProperty Name="Carts" Relationship="EcommerceAppModel.FK__Cart__IdUser__45F365D3" FromRole="MUser" ToRole="Cart" />
           <NavigationProperty Name="CategoryRequests" Relationship="EcommerceAppModel.FK_CategoryRequest_Shop" FromRole="MUser" ToRole="CategoryRequest" />
           <NavigationProperty Name="MOrders" Relationship="EcommerceAppModel.FK_MOrder_MUser" FromRole="MUser" ToRole="MOrder" />
           <NavigationProperty Name="MOrders1" Relationship="EcommerceAppModel.FK_MOrder_Shop" FromRole="MUser" ToRole="MOrder" />
-          <NavigationProperty Name="ShopRequests" Relationship="EcommerceAppModel.FK__ShopReque__IdUse__70DDC3D8" FromRole="MUser" ToRole="ShopRequest" />
+          <NavigationProperty Name="ShopRequests" Relationship="EcommerceAppModel.FK__ShopReque__IdUse__73BA3083" FromRole="MUser" ToRole="ShopRequest" />
           <NavigationProperty Name="UserLogin" Relationship="EcommerceAppModel.FK_MUser_Id" FromRole="MUser" ToRole="UserLogin" />
           <NavigationProperty Name="Notifications" Relationship="EcommerceAppModel.FK_Notification_UserReceiver" FromRole="MUser" ToRole="Notification" />
           <NavigationProperty Name="Notifications1" Relationship="EcommerceAppModel.FK_Notification_UserSender" FromRole="MUser" ToRole="Notification" />
@@ -1037,6 +1040,7 @@
           <Property Name="IdSender" Type="String" Nullable="false" MaxLength="30" FixedLength="false" Unicode="false" />
           <Property Name="Date" Type="DateTime" Nullable="false" Precision="0" />
           <Property Name="Content" Type="String" Nullable="false" MaxLength="1000" FixedLength="false" Unicode="true" />
+          <Property Name="HaveSeen" Type="Boolean" />
           <NavigationProperty Name="MUser" Relationship="EcommerceAppModel.FK_Notification_UserReceiver" FromRole="Notification" ToRole="MUser" />
           <NavigationProperty Name="MUser1" Relationship="EcommerceAppModel.FK_Notification_UserSender" FromRole="Notification" ToRole="MUser" />
         </EntityType>
@@ -1081,7 +1085,7 @@
           <Property Name="DateOfSale" Type="DateTime" Precision="0" />
           <Property Name="BanLevel" Type="Int32" />
           <NavigationProperty Name="Brand" Relationship="EcommerceAppModel.FK_Product_Brand" FromRole="Product" ToRole="Brand" />
-          <NavigationProperty Name="Carts" Relationship="EcommerceAppModel.FK__Cart__IdProduct__440B1D61" FromRole="Product" ToRole="Cart" />
+          <NavigationProperty Name="Carts" Relationship="EcommerceAppModel.FK__Cart__IdProduct__46E78A0C" FromRole="Product" ToRole="Cart" />
           <NavigationProperty Name="Category" Relationship="EcommerceAppModel.FK_Product_Category" FromRole="Product" ToRole="Category" />
           <NavigationProperty Name="ImageProducts" Relationship="EcommerceAppModel.FK_IP_Product" FromRole="Product" ToRole="ImageProduct" />
           <NavigationProperty Name="MUser" Relationship="EcommerceAppModel.FK_Product_Shop" FromRole="Product" ToRole="MUser" />
@@ -1095,7 +1099,7 @@
           </Key>
           <Property Name="Id" Type="String" Nullable="false" MaxLength="8" FixedLength="false" Unicode="false" />
           <Property Name="IdShop" Type="String" Nullable="false" MaxLength="30" FixedLength="false" Unicode="false" />
-          <Property Name="Code" Type="String" Nullable="false" MaxLength="15" FixedLength="false" Unicode="false" />
+          <Property Name="Code" Type="String" Nullable="false" MaxLength="15" FixedLength="false" Unicode="true" />
           <Property Name="Name" Type="String" MaxLength="150" FixedLength="false" Unicode="true" />
           <Property Name="Description" Type="String" MaxLength="200" FixedLength="false" Unicode="true" />
           <Property Name="DateBegin" Type="DateTime" Precision="0" />
@@ -1129,7 +1133,7 @@
           <Property Name="Id" Type="String" Nullable="false" MaxLength="8" FixedLength="false" Unicode="false" />
           <Property Name="DateRating" Type="DateTime" Precision="0" />
           <Property Name="Rating1" Type="Int32" />
-          <Property Name="Comment" Type="String" MaxLength="500" FixedLength="false" Unicode="false" />
+          <Property Name="Comment" Type="String" MaxLength="500" FixedLength="false" Unicode="true" />
           <NavigationProperty Name="OrderInfoes" Relationship="EcommerceAppModel.FK_MOrder_Rating" FromRole="Rating" ToRole="OrderInfo" />
           <NavigationProperty Name="RatingInfoes" Relationship="EcommerceAppModel.FK_RatingInfo_IdRating" FromRole="Rating" ToRole="RatingInfo" />
         </EntityType>
@@ -1153,7 +1157,7 @@
           <Property Name="Id" Type="String" Nullable="false" MaxLength="8" FixedLength="false" Unicode="false" />
           <Property Name="IdUser" Type="String" MaxLength="30" FixedLength="false" Unicode="false" />
           <Property Name="Description" Type="String" MaxLength="1000" FixedLength="false" Unicode="true" />
-          <NavigationProperty Name="MUser" Relationship="EcommerceAppModel.FK__ShopReque__IdUse__70DDC3D8" FromRole="ShopRequest" ToRole="MUser" />
+          <NavigationProperty Name="MUser" Relationship="EcommerceAppModel.FK__ShopReque__IdUse__73BA3083" FromRole="ShopRequest" ToRole="MUser" />
         </EntityType>
         <Association Name="FK_Address_IdUser">
           <End Type="EcommerceAppModel.MUser" Role="MUser" Multiplicity="1" />
@@ -1167,7 +1171,7 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK__AdInUse__Id__5535A963">
+        <Association Name="FK__AdInUse__Id__5812160E">
           <End Type="EcommerceAppModel.Advertisement" Role="Advertisement" Multiplicity="1" />
           <End Type="EcommerceAppModel.AdInUse" Role="AdInUse" Multiplicity="*" />
           <ReferentialConstraint>
@@ -1203,7 +1207,7 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK__Cart__IdProduct__440B1D61">
+        <Association Name="FK__Cart__IdProduct__46E78A0C">
           <End Type="EcommerceAppModel.Product" Role="Product" Multiplicity="1" />
           <End Type="EcommerceAppModel.Cart" Role="Cart" Multiplicity="*" />
           <ReferentialConstraint>
@@ -1215,7 +1219,7 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK__Cart__IdUser__4316F928">
+        <Association Name="FK__Cart__IdUser__45F365D3">
           <End Type="EcommerceAppModel.MUser" Role="MUser" Multiplicity="1" />
           <End Type="EcommerceAppModel.Cart" Role="Cart" Multiplicity="*" />
           <ReferentialConstraint>
@@ -1311,7 +1315,7 @@
             </Dependent>
           </ReferentialConstraint>
         </Association>
-        <Association Name="FK__ShopReque__IdUse__70DDC3D8">
+        <Association Name="FK__ShopReque__IdUse__73BA3083">
           <End Type="EcommerceAppModel.MUser" Role="MUser" Multiplicity="0..1" />
           <End Type="EcommerceAppModel.ShopRequest" Role="ShopRequest" Multiplicity="*" />
           <ReferentialConstraint>
@@ -1482,6 +1486,7 @@
           <EntitySetMapping Name="UserLogins">
             <EntityTypeMapping TypeName="EcommerceAppModel.UserLogin">
               <MappingFragment StoreEntitySet="UserLogin">
+                <ScalarProperty Name="CreatedDate" ColumnName="CreatedDate" />
                 <ScalarProperty Name="Salt" ColumnName="Salt" />
                 <ScalarProperty Name="Provider" ColumnName="Provider" />
                 <ScalarProperty Name="Username" ColumnName="Username" />
@@ -1605,6 +1610,7 @@
           <EntitySetMapping Name="Notifications">
             <EntityTypeMapping TypeName="EcommerceAppModel.Notification">
               <MappingFragment StoreEntitySet="Notification">
+                <ScalarProperty Name="HaveSeen" ColumnName="HaveSeen" />
                 <ScalarProperty Name="Content" ColumnName="Content" />
                 <ScalarProperty Name="Date" ColumnName="Date" />
                 <ScalarProperty Name="IdSender" ColumnName="IdSender" />

--- a/WPFEcommerceApp/WPFEcommerceApp/Models/Model.edmx.diagram
+++ b/WPFEcommerceApp/WPFEcommerceApp/Models/Model.edmx.diagram
@@ -12,26 +12,26 @@
 					<AssociationConnector Association="EcommerceAppModel.FK_Orderinfor_Shop" />
 					<AssociationConnector Association="EcommerceAppModel.FK_RatingInfo_Product" />
 					<AssociationConnector Association="EcommerceAppModel.FK_RatingInfo_Rating" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Address" Width="1.5" PointX="3.9738586526242363" PointY="28.011582179000406" />
-        <EntityTypeShape EntityType="EcommerceAppModel.AdInUse" Width="1.5" PointX="4.2461352833761534" PointY="29.659834234816877" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Advertisement" Width="1.5" PointX="9.60967754088793" PointY="20.556686008608288" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Brand" Width="1.5" PointX="9.1173429047303927" PointY="8.1147629805443628" />
-        <EntityTypeShape EntityType="EcommerceAppModel.BrandRequest" Width="1.5" PointX="1.3708490772968387" PointY="10.241136719584995" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Category" Width="1.5" PointX="4.3378800304317284" PointY="6.2915784745903585" />
-        <EntityTypeShape EntityType="EcommerceAppModel.CategoryRequest" Width="1.5" PointX="2.1411164077655958" PointY="19.810844818042053" />
-        <EntityTypeShape EntityType="EcommerceAppModel.ImageProduct" Width="1.5" PointX="1.2249959712964464" PointY="24.004684131594693" />
-        <EntityTypeShape EntityType="EcommerceAppModel.MOrder" Width="1.5" PointX="3.2352771289810898" PointY="11.232643877730073" />
-        <EntityTypeShape EntityType="EcommerceAppModel.MUser" Width="1.5" PointX="2.3770709607643408" PointY="25.196132060697362" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Notification" Width="1.5" PointX="0.425605707068744" PointY="8.8974224966473052" />
-        <EntityTypeShape EntityType="EcommerceAppModel.OrderInfo" Width="1.5" PointX="2.178761328653787" PointY="7.7913230395835464" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Product" Width="1.5" PointX="0.1049949042987986" PointY="28.095668582290255" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Promo" Width="1.5" PointX="7.7517024482375483" PointY="14.841019458529082" />
-        <EntityTypeShape EntityType="EcommerceAppModel.PromoRequest" Width="1.5" PointX="9.8506202929888946" PointY="22.830839733980056" />
-        <EntityTypeShape EntityType="EcommerceAppModel.Rating" Width="1.5" PointX="9.025321817502995" PointY="20.011906081816139" />
-        <EntityTypeShape EntityType="EcommerceAppModel.RatingInfo" Width="1.5" PointX="0.64553227864463447" PointY="1.1944285487730188" />
-        <EntityTypeShape EntityType="EcommerceAppModel.ShopRequest" Width="1.5" PointX="0.057525381472672048" PointY="28.626484258392122" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Address" Width="1.5" PointX="11.533636288500222" PointY="4.5654808006088627" />
+        <EntityTypeShape EntityType="EcommerceAppModel.AdInUse" Width="1.5" PointX="0.34350831822655553" PointY="20.7072305328712" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Advertisement" Width="1.5" PointX="11.324983197881368" PointY="29.958378865364185" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Brand" Width="1.5" PointX="11.523921908589044" PointY="23.786131393064807" />
+        <EntityTypeShape EntityType="EcommerceAppModel.BrandRequest" Width="1.5" PointX="10.31110935765836" PointY="15.278976849875868" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Category" Width="1.5" PointX="3.4549943038518514" PointY="16.696753464963638" />
+        <EntityTypeShape EntityType="EcommerceAppModel.CategoryRequest" Width="1.5" PointX="10.317317408657315" PointY="20.084465811068409" />
+        <EntityTypeShape EntityType="EcommerceAppModel.ImageProduct" Width="1.5" PointX="6.5550999560184309" PointY="1.5033038116541244" />
+        <EntityTypeShape EntityType="EcommerceAppModel.MOrder" Width="1.5" PointX="0.64843021549677027" PointY="15.787402935227101" />
+        <EntityTypeShape EntityType="EcommerceAppModel.MUser" Width="1.5" PointX="5.736543469939634" PointY="11.813199033873714" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Notification" Width="1.5" PointX="2.5779089045607995" PointY="15.598658986202748" />
+        <EntityTypeShape EntityType="EcommerceAppModel.OrderInfo" Width="1.5" PointX="1.1854493027485205" PointY="4.9411283009411431" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Product" Width="1.5" PointX="4.1745053660937144" PointY="25.165733036196666" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Promo" Width="1.5" PointX="7.9311817660607318" PointY="18.139556744200902" />
+        <EntityTypeShape EntityType="EcommerceAppModel.PromoRequest" Width="1.5" PointX="10.632530316073694" PointY="31.220492556328182" />
+        <EntityTypeShape EntityType="EcommerceAppModel.Rating" Width="1.5" PointX="2.534831309008799" PointY="14.17805973355568" />
+        <EntityTypeShape EntityType="EcommerceAppModel.RatingInfo" Width="1.5" PointX="3.4502052420052722" PointY="13.262833094812386" />
+        <EntityTypeShape EntityType="EcommerceAppModel.ShopRequest" Width="1.5" PointX="6.6513622471370564" PointY="22.626325275109302" />
         <AssociationConnector Association="EcommerceAppModel.FK_Address_IdUser" />
-        <AssociationConnector Association="EcommerceAppModel.FK__AdInUse__Id__5535A963" />
+        <AssociationConnector Association="EcommerceAppModel.FK__AdInUse__Id__5812160E" />
         <AssociationConnector Association="EcommerceAppModel.FK_Product_Brand" />
         <AssociationConnector Association="EcommerceAppModel.FK_BrandRequest_Shop" />
         <AssociationConnector Association="EcommerceAppModel.FK_Product_Category" />
@@ -41,7 +41,7 @@
         <AssociationConnector Association="EcommerceAppModel.FK_MOrder_Promo" />
         <AssociationConnector Association="EcommerceAppModel.FK_MOrder_Shop" />
         <AssociationConnector Association="EcommerceAppModel.FK_OrderInfo_MOrder" />
-        <AssociationConnector Association="EcommerceAppModel.FK__ShopReque__IdUse__70DDC3D8" />
+        <AssociationConnector Association="EcommerceAppModel.FK__ShopReque__IdUse__73BA3083" />
         <AssociationConnector Association="EcommerceAppModel.FK_Notification_UserReceiver" />
         <AssociationConnector Association="EcommerceAppModel.FK_Notification_UserSender" />
         <AssociationConnector Association="EcommerceAppModel.FK_Product_Shop" />

--- a/WPFEcommerceApp/WPFEcommerceApp/Models/Model1.Designer.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Models/Model1.Designer.cs
@@ -1,4 +1,4 @@
-﻿// T4 code generation is enabled for model 'T:\git\WPFEcommerceAPP\WPFEcommerceApp\WPFEcommerceApp\Models\Model.edmx'. 
+﻿// T4 code generation is enabled for model 'H:\Dev\Projects\WPFEcommerceAPP\WPFEcommerceApp\WPFEcommerceApp\Models\Model.edmx'. 
 // To enable legacy code generation, change the value of the 'Code Generation Strategy' designer
 // property to 'Legacy ObjectContext'. This property is available in the Properties Window when the model
 // is open in the designer.

--- a/WPFEcommerceApp/WPFEcommerceApp/Models/Notification.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Models/Notification.cs
@@ -19,6 +19,7 @@ namespace WPFEcommerceApp.Models
         public string IdSender { get; set; }
         public System.DateTime Date { get; set; }
         public string Content { get; set; }
+        public Nullable<bool> HaveSeen { get; set; }
     
         public virtual MUser MUser { get; set; }
         public virtual MUser MUser1 { get; set; }

--- a/WPFEcommerceApp/WPFEcommerceApp/Models/UserLogin.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Models/UserLogin.cs
@@ -19,6 +19,7 @@ namespace WPFEcommerceApp.Models
         public string Username { get; set; }
         public Nullable<int> Provider { get; set; }
         public string Salt { get; set; }
+        public Nullable<System.DateTime> CreatedDate { get; set; }
     
         public virtual MUser MUser { get; set; }
     }

--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Filter/FilterViewModel.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Filter/FilterViewModel.cs
@@ -542,7 +542,9 @@ namespace WPFEcommerceApp
             {
                 Condition.Brands = new List<string>();
             }
-            if (Condition.ShopText == null)
+            //VHCMT: Vì Condition.ShopText đổi từ null => ""
+            //=> Thay đổi filterObject => Back về sẽ chuyển sang else
+            if (string.IsNullOrEmpty(Condition.ShopText))
             {
                 Condition.ShopText = "";
                 SearchBy = "In WANO";

--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/DescriptionConverter.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/DescriptionConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace WPFEcommerceApp {
+    internal class DescriptionConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            string description = (string)value;
+            description = description.Trim();
+            description = description.Substring(0, 196);
+            description += "...";
+            return description;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/Dialog/ReviewProductDialog.xaml
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/Dialog/ReviewProductDialog.xaml
@@ -26,7 +26,7 @@
                         BorderThickness="0 0.5"
                         x:Name="prdBorder" Width="395" HorizontalAlignment="Right"/>
                     <DockPanel Panel.ZIndex="1">
-                        <Grid x:Name="imgContainer" Background="Pink"
+                        <Grid x:Name="imgContainer" Background="Transparent"
                               Width="70" Height="70">
                             <local:AsyncImage Source="{Binding Product.ProductImage}" 
                                               Stretch="Uniform"

--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/ProductDetailShopCard.xaml
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/ProductDetailShopCard.xaml
@@ -3,6 +3,7 @@
                     xmlns:i="clr-namespace:CalcBinding;assembly=CalcBinding"
                     xmlns:fa= "http://schemas.fontawesome.io/icons/"
                     xmlns:vm="clr-namespace:WPFEcommerceApp"
+                    xmlns:c="clr-namespace:CalcBinding;assembly=CalcBinding"
                     xmlns:it="http://schemas.microsoft.com/xaml/behaviors"
                     x:Class="WPFEcommerceApp.ProductDetailShopCard"
                     xmlns:materialDesign = "http://materialdesigninxaml.net/winfx/xaml/themes">
@@ -36,6 +37,7 @@
     </Style>
 
     <vm:MultiValueConverter x:Key="MultiValueConverter"/>
+    <vm:DescriptionConverter x:Key="DescriptionConverter"/>
 
     <DataTemplate x:Key="ProductCard" DataType="{x:Type vm:Product}">
         <Button Width="{i:Binding ElementName=prdContainer, Path=ActualWidth-10}"
@@ -53,8 +55,8 @@
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="1*"/>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="5*"/>
+                        <ColumnDefinition Width="1*"/>
                         <ColumnDefinition Width="1*"/>
                     </Grid.ColumnDefinitions>
 
@@ -64,7 +66,7 @@
                     </Grid>
 
                     <StackPanel Grid.Column="1" VerticalAlignment="Center"
-                                Margin="15 0 0 0">
+                                Margin="15 0 0 0" x:Name="OtherDetailCtn">
                         <TextBlock Text="{Binding Name}" FontSize="19" TextWrapping="Wrap"
                                Margin="5 0 0 0"/>
                         <StackPanel Orientation="Horizontal" Margin="5, 9, 0, 0">
@@ -75,9 +77,16 @@
                             <TextBlock Text="Color: " FontSize="13" Foreground="{StaticResource BlackColorBrush}"/>
                             <TextBlock Text="{Binding Color}" FontSize="13" Foreground="{StaticResource BlackColorBrush}"/>
                         </StackPanel>
+
                         <StackPanel Orientation="Horizontal" Margin="5, 5, 0, 0">
                             <TextBlock Text="Other Detail: " FontSize="13" Foreground="{StaticResource BlackColorBrush}"/>
-                            <TextBlock Text="{Binding Description}" FontSize="13" Foreground="{StaticResource BlackColorBrush}"/>
+                            <TextBlock Text="{Binding Description, Converter={StaticResource DescriptionConverter}}"
+                                       FontSize="13" 
+                                       MaxHeight="60"
+                                       MaxWidth="{c:Binding ElementName=OtherDetailCtn, Path=ActualWidth-150}"
+                                       Foreground="{StaticResource BlackColorBrush}"
+                                       TextTrimming="CharacterEllipsis"
+                                       TextWrapping="WrapWithOverflow"/>
                         </StackPanel>
                     </StackPanel>
 

--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/ProductOrderCard.xaml
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Order/components/ProductOrderCard.xaml
@@ -3,16 +3,20 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:c="clr-namespace:CalcBinding;assembly=CalcBinding"
              xmlns:local="clr-namespace:WPFEcommerceApp"
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="1111">
+    <UserControl.Resources>
+        <local:DescriptionConverter x:Key="DescriptionConverter"/>
+    </UserControl.Resources>
     <StackPanel Background="White">
         <Separator BorderThickness="0 0 0 0.5" BorderBrush="{StaticResource NotAvailableColorBrush}" VerticalAlignment="Top" Margin="0, 0,0,20"/>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1*"/>
-                <ColumnDefinition Width="3*"/>
-                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="5*"/>
+                <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="1*"/>
             </Grid.ColumnDefinitions>
 
@@ -21,7 +25,7 @@
                        Height="{Binding Height, ElementName=ImageContainer}" Stretch="Uniform" HorizontalAlignment="Center"/>
             </Grid>
 
-            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+            <StackPanel Grid.Column="1" VerticalAlignment="Center" x:Name="OtherDetailCtn">
                 <TextBlock Text="{Binding Name}" FontSize="18" TextWrapping="Wrap" Margin="5 0 0 0"/>
                 <StackPanel Orientation="Horizontal" Margin="5, 9, 0, 0">
                     <TextBlock Text="Size: " FontSize="12" Foreground="{StaticResource BlackColorBrush}"/>
@@ -33,7 +37,13 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="5, 5, 0, 0">
                     <TextBlock Text="Other Detail: " FontSize="12" Foreground="{StaticResource BlackColorBrush}"/>
-                    <TextBlock Text="{Binding Description}" FontSize="12" Foreground="{StaticResource BlackColorBrush}"/>
+                    <TextBlock Text="{Binding Description, Converter={StaticResource DescriptionConverter}}" 
+                               FontSize="12" 
+                               MaxHeight="60"
+                               MaxWidth="{c:Binding ElementName=OtherDetailCtn, Path=ActualWidth-150}"
+                               Foreground="{StaticResource BlackColorBrush}"
+                               TextTrimming="CharacterEllipsis"
+                               TextWrapping="WrapWithOverflow"/>
                 </StackPanel>
             </StackPanel>
             <StackPanel Orientation="Horizontal" 

--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Payment/Checkout/CheckoutScreenVM.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Payment/Checkout/CheckoutScreenVM.cs
@@ -315,8 +315,12 @@ namespace WPFEcommerceApp {
             var valid = new List<Promo>();
             var invalid = new List<Promo>();
 
+            var listShop = ListOrder.Select(s => s.IDShop).ToList();
+
             var listVoucher = await promoRepo.GetListAsync(
-                d => d.DateEnd > DateTime.Now && d.Status == 1,
+                d => d.DateEnd > DateTime.Now && 
+                     d.Status == 1 &&
+                     listShop.Contains(d.IdShop),
                 d => d.Products
             );
 
@@ -331,13 +335,19 @@ namespace WPFEcommerceApp {
             foreach(var o in listVoucher) {
                 var flag = true;
                 //if(o.Products.Count == 0) flag = false;
-                if(o.Products.Count < productList.Count || o.Products.Count == 0) {
+                //if(CurrentUser)
+                
+                if(o.Products.Count < productList.Count || 
+                    o.Products.Count == 0 ||
+                    (o.CustomerType == 0 && DateTime.Now - CurrentUser.UserLogin.CreatedDate > TimeSpan.FromDays(7)) ||
+                    o.MinCost > SubTotal) {
                     flag = false;
                 }
                 else {
                     List<string> listVoucherId = o.Products.Select(d => d.Id).ToList();
                     flag = !productList.Except(listVoucherId).Any();
                 }
+
                 if(flag) {
                     valid.Add(o);
                     ValidVoucherList.Add(o.Id, true);

--- a/WPFEcommerceApp/WPFEcommerceApp/Stores/OrderStore.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Stores/OrderStore.cs
@@ -123,6 +123,7 @@ namespace WPFEcommerceApp {
             temp.IdCustomer = p.IDCustomer;
             temp.IdShop = p.IDShop;
             temp.ShipTotal = (int)p.ShipTotal;
+            temp.Discounted = p.Discount;
             temp.DateBegin = p.DateBegin;
             temp.DateEnd = p.DateEnd;
             temp.Promo = p.Promo;

--- a/WPFEcommerceApp/WPFEcommerceApp/WPFEcommerceApp.csproj
+++ b/WPFEcommerceApp/WPFEcommerceApp/WPFEcommerceApp.csproj
@@ -162,14 +162,6 @@
     <Compile Include="Models\UserLogin.cs">
       <DependentUpon>Model.tt</DependentUpon>
     </Compile>
-    <Compile Include="Screens\General\ProductDetail\ProductDetail.xaml.cs">
-      <DependentUpon>ProductDetail.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Screens\General\ProductDetail\ProductDetailBanned\ProductDetailBannedViewModel.cs" />
-    <Compile Include="Screens\General\ProductDetail\ProductDetailBanned\ProductDetailBanned.xaml.cs">
-      <DependentUpon>ProductDetailBanned.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Screens\General\ProductDetail\ProductDetailViewModel.cs" />
     <Compile Include="Screens\General\Payment\Checkout\VoucherFilterConverter.cs" />
     <Compile Include="Screens\General\Payment\components\Dialogs\EditInforDialogVM.cs" />
     <Compile Include="Screens\General\Payment\components\Dialogs\VoucherConditionDialog.xaml.cs">
@@ -178,6 +170,14 @@
     <Compile Include="Screens\General\ProductDetailMini\ProductDetailMini.xaml.cs">
       <DependentUpon>ProductDetailMini.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Screens\General\ProductDetail\ProductDetailBanned\ProductDetailBanned.xaml.cs">
+      <DependentUpon>ProductDetailBanned.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Screens\General\ProductDetail\ProductDetailBanned\ProductDetailBannedViewModel.cs" />
+    <Compile Include="Screens\General\ProductDetail\ProductDetailNormal\ProductDetailNormal.xaml.cs">
+      <DependentUpon>ProductDetailNormal.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Screens\General\ProductDetail\ProductDetailNormal\ProductDetailNormalViewModel.cs" />
     <Compile Include="Screens\Shop\ShopOrder\ShopOrderBlock\OrderInfoPdf\OrderInfoPdf.xaml.cs">
       <DependentUpon>OrderInfoPdf.xaml</DependentUpon>
     </Compile>
@@ -346,10 +346,10 @@
       <DependentUpon>NotificationBlockUC.xaml</DependentUpon>
     </Compile>
     <Compile Include="Screens\General\Notification\NotificationViewModel.cs" />
-    <Compile Include="Screens\General\ProductDetail\ProductDetailNormal\ProductDetailNormal.xaml.cs">
-      <DependentUpon>ProductDetailNormal.xaml</DependentUpon>
+    <Compile Include="Screens\General\ProductDetail\ProductDetail.xaml.cs">
+      <DependentUpon>ProductDetail.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Screens\General\ProductDetail\ProductDetailNormal\ProductDetailNormalViewModel.cs" />
+    <Compile Include="Screens\General\ProductDetail\ProductDetailViewModel.cs" />
     <Compile Include="Screens\Auth\Register\Register.xaml.cs">
       <DependentUpon>Register.xaml</DependentUpon>
     </Compile>
@@ -626,14 +626,6 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="Screens\General\ProductDetail\ProductDetail.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Screens\General\ProductDetail\ProductDetailBanned\ProductDetailBanned.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
     <Page Include="Screens\Admin\AdminPromo\AdminPromo.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -665,6 +657,14 @@
     <Page Include="Screens\General\ProductDetailMini\ProductDetailMini.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Screens\General\ProductDetail\ProductDetailBanned\ProductDetailBanned.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Screens\General\ProductDetail\ProductDetailNormal\ProductDetailNormal.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Screens\Shop\ShopOrder\ShopOrderBlock\OrderInfoPdf\OrderInfoPdf.xaml">
       <SubType>Designer</SubType>
@@ -925,7 +925,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="Screens\General\ProductDetail\ProductDetailNormal\ProductDetailNormal.xaml">
+    <Page Include="Screens\General\ProductDetail\ProductDetail.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -1309,7 +1309,6 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Assets\Images\img_CoverHolder.jpg" />
-    <Resource Include="Assets\Images\MagicBox.png" />
     <Content Include="Screens\Auth\ForgotPassword\email.html" />
     <Resource Include="Assets\Icon\icon_facebook.png" />
     <Resource Include="Assets\Icon\icon_github.png" />

--- a/WPFEcommerceApp/WPFEcommerceApp/WPFEcommerceApp.csproj
+++ b/WPFEcommerceApp/WPFEcommerceApp/WPFEcommerceApp.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Models\UserLogin.cs">
       <DependentUpon>Model.tt</DependentUpon>
     </Compile>
+    <Compile Include="Screens\General\Order\components\DescriptionConverter.cs" />
     <Compile Include="Screens\General\Payment\Checkout\VoucherFilterConverter.cs" />
     <Compile Include="Screens\General\Payment\components\Dialogs\EditInforDialogVM.cs" />
     <Compile Include="Screens\General\Payment\components\Dialogs\VoucherConditionDialog.xaml.cs">


### PR DESCRIPTION
# Update: 
- `UserLogin`: Thêm `CreatedDate` để check Promo
- `GenarateID`: Tôi làm thêm 1 cái `Fake ID` cho các bạn đỡ phải sửa lại ID trong DB. Chỉ cần mở comment phần `Fake ID` comment lại phần `Real ID` là được. Nhớ nếu có push code lên thì không push lại file này. @Karin1412 @kimthu09 
- `Filter`: Tôi chỉnh lại Constructor để Back về không bị sai param. Tìm `VHCMT`. @NLNM-0-0 
- `App.config`: Tôi chỉnh lại file này vì mình thêm phần `Cookie` trong `Settings`. Lý do mà máy tôi phải xóa đi đặt lại là vì App.config không cài sẵn.
# Bug (Các bạn xem để hỗ trợ tôi với Mai test)
- Brand + Category request bị phình ra khi description dài
- Sản phẩm bị trùng trên trang Home (More vs best seller)
- Giá vẫn bị gạch khi không giảm giá
- Lỗi Promo: 
	+ Không xóa các sản phẩm đã chọn ra khỏi mục add sản phẩm
	+ Target Customer luôn là New User
- Nên có viền phân biệt giữa Ava vs Cover
- Lỗi cắt ảnh: 
	+ Ảnh khi phóng to + di chuyển => Khi thu nhỏ lại rồi save sẽ lỗi
- Minishop bị thay đổi khi đổi kích thước ảnh
- Bag: 
	+ Không trượt xuống được khi có nhiều sản phẩm
	+ Tên sản phẩm và tên shop đè lên nhau
- Shop Order:
	+ Giá Subtotal ở mỗi sản phẩm bị sai
	+ Giá shipping = 2.5 nếu fast ship, 0 nếu free
- Shop main:
	+ Rating bị tràn
- Chưa chia folder trên storage cho ảnh product
- Lỗi không load ảnh 
=> Vấn đề của việc new ViewModel mỗi lần chuyển tab
=> Cần lưu cache của ViewModel