### PR TITLE
fix: Search in Filter, the way get BestSeller List in ShopMain

### DIFF
--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Filter/FilterViewModel.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/General/Filter/FilterViewModel.cs
@@ -702,11 +702,7 @@ namespace WPFEcommerceApp
                 }
             }
             int maxLength = FilterProducts.Count;
-            if(!IsAllFilter)
-            {
-                maxLength = Math.Min(50, FilterProducts.Count);
-            }
-            DisplayedProducts.Clear();
+            IList<ProductBlockViewModel> tempProducts = new List<ProductBlockViewModel>();
             if (isHasSize)
             {
                 if (SearchBy == "In WANO")
@@ -720,7 +716,7 @@ namespace WPFEcommerceApp
                                                                     ((CheckSize[1] && p.SelectedProduct.IsHadSizeS == CheckSize[1])) || (CheckSize[2] && (p.SelectedProduct.IsHadSizeM == CheckSize[2])) || (CheckSize[3] && (p.SelectedProduct.IsHadSizeL == CheckSize[3])) ||
                                                                     (CheckSize[4] && (p.SelectedProduct.IsHadSizeXL == CheckSize[4])) || (CheckSize[5] && (p.SelectedProduct.IsHadSizeXXL == CheckSize[5]))))))
                         {
-                            DisplayedProducts.Add(p);
+                            tempProducts.Add(p);
                         }
                     }
                     IsNeedSearchBy = false;
@@ -736,7 +732,7 @@ namespace WPFEcommerceApp
                                                                     ((CheckSize[1] && p.SelectedProduct.IsHadSizeS == CheckSize[1])) || (CheckSize[2] && (p.SelectedProduct.IsHadSizeM == CheckSize[2])) || (CheckSize[3] && (p.SelectedProduct.IsHadSizeL == CheckSize[3])) ||
                                                                     (CheckSize[4] && (p.SelectedProduct.IsHadSizeXL == CheckSize[4])) || (CheckSize[5] && (p.SelectedProduct.IsHadSizeXXL == CheckSize[5])))))
                         {
-                            DisplayedProducts.Add(p);
+                            tempProducts.Add(p);
                         }
                     }
                 }
@@ -752,7 +748,7 @@ namespace WPFEcommerceApp
                                                                     (p.SelectedProduct.Price * (100 - p.SelectedProduct.Sale) / 100 <= MaxPrice && p.SelectedProduct.Price * (100 - p.SelectedProduct.Sale) / 100 >= MinPrice) &&
                                                                     (listCategoryId.Contains(p.SelectedProduct.IdCategory)) && (listBrandId.Contains(p.SelectedProduct.IdBrand)))
                         {
-                            DisplayedProducts.Add(p);
+                            tempProducts.Add(p);
                         }
                     }
                     IsNeedSearchBy = false;
@@ -766,11 +762,19 @@ namespace WPFEcommerceApp
                                                                     (p.SelectedProduct.Price * (100 - p.SelectedProduct.Sale) / 100 <= MaxPrice && p.SelectedProduct.Price * (100 - p.SelectedProduct.Sale) / 100 >= MinPrice) &&
                                                                     (listCategoryId.Contains(p.SelectedProduct.IdCategory)) && (listBrandId.Contains(p.SelectedProduct.IdBrand)))
                         {
-                            DisplayedProducts.Add(p);
+                            tempProducts.Add(p);
                         }
                     }
                 }
             }
+            if (!IsAllFilter)
+            {
+                DisplayedProducts = tempProducts.Take(50).ToList();
+            }
+            else
+            {
+                DisplayedProducts = tempProducts;
+            }    
         }
         private async Task Load()
         {

--- a/WPFEcommerceApp/WPFEcommerceApp/Screens/Shop/ShopMain/ShopMainViewModel.cs
+++ b/WPFEcommerceApp/WPFEcommerceApp/Screens/Shop/ShopMain/ShopMainViewModel.cs
@@ -386,7 +386,7 @@ namespace WPFEcommerceApp
             }
             AverageRating = sumRating * 1.0 / number;
             BigDiscountProducts = new ObservableCollection<Models.Product>(AllProducts.Where(p=>p.Sale > 0).OrderByDescending(p => p.Sale).Take(16));
-            BestSellerProducts = new ObservableCollection<Models.Product>(AllProducts.Where(p => p.OrderInfoes.Count > 0).OrderByDescending(p => p.OrderInfoes.Count).Take(16));
+            BestSellerProducts = new ObservableCollection<Models.Product>(AllProducts.Where(p => p.Sold > 0).OrderByDescending(p => p.Sold).Take(16));
             if (lastDateHasNewProduct != DateTime.MinValue)
             {
                 NewProducts = new ObservableCollection<Models.Product>(AllProducts.Where(p => (lastDateHasNewProduct - p.DateOfSale) <= new TimeSpan(7, 0, 0, 0)).ToList().OrderByDescending(p => p.DateOfSale).Take(16));


### PR DESCRIPTION
Sửa lại thuật search ở Filter (giới hạn 50 products lúc ban đầu => không thể áp dụng khi search product theo shop) và cách lấy dữ liệu ở BestSeller List tại SHopMain